### PR TITLE
Fix possible timeout introduced by assertion in Bits

### DIFF
--- a/hw3/src/main/java/edu/berkeley/cs186/database/common/Bits.java
+++ b/hw3/src/main/java/edu/berkeley/cs186/database/common/Bits.java
@@ -28,7 +28,7 @@ public class Bits {
    *   - getBit(new byte[]{0b00000000, 0b00000001}, 15) == ONE
    */
   public static Bit getBit(byte[] bytes, int i) {
-    String err = String.format("bytes.length = %d; i = %d.", bytes.length, i);
+    String err = "bytes.length = " + bytes.length + "; i = " + i + ".";
     assert (bytes.length > 0) : err;
     assert (0 <= i && i < bytes.length * 8) : err;
     return getBit(bytes[i/8], i % 8);


### PR DESCRIPTION
String.format() is expansive in that it uses RegEx and current Locale's DecimalFormat, especially in a method that's called for every bit. Refactoring this to use plain string concatenation preserves the functionality and reduced tes time by ~80% on my machine with OpenJDK.